### PR TITLE
pin version of the container used

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
             extension: .exe
 
     container:
-      image: ghcr.io/arduino/crossbuild:latest
+      image: ghcr.io/arduino/crossbuild:0.1.1
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.RP2040_CI_PAT }}


### PR DESCRIPTION
The `latest` tag currently points to `0.2.0` version. In this version, we changed the locations of the libraries. Pinning it this way, we ensure the build continue to work just fine.