### PR TITLE
add taskfile and use it in the release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -160,10 +160,16 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v3
       with:
-          go-version: "1.16.2"
+        go-version: "1.16.2"
+
+    - name: Install Task
+      uses: arduino/setup-task@v1
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        version: 3.x
 
     - name: Build rp2040load
-      run: go build -ldflags '-X main.version=${GITHUB_REF##*/}'
+      run: task go:build
       env:
         GOOS: ${{ matrix.config.os }}
         GOARCH: ${{ matrix.config.arch }}

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,0 +1,32 @@
+# See: https://taskfile.dev/#/usage
+version: "3"
+
+vars:
+  # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/release-go-task/Taskfile.yml
+  PROJECT_NAME: rp2040load
+  DIST_DIR: "dist"
+  # build vars
+  COMMIT:
+    sh: echo "$(git log --no-show-signature -n 1 --format=%h)"
+  TIMESTAMP:
+    sh: echo "$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+  TIMESTAMP_SHORT:
+    sh: echo "{{now | date "20060102"}}"
+  TAG:
+    sh: echo "$(git tag --points-at=HEAD 2> /dev/null | head -n1)"
+  VERSION: "{{if .NIGHTLY}}nightly-{{.TIMESTAMP_SHORT}}{{else if .TAG}}{{.TAG}}{{else}}{{.PACKAGE_NAME_PREFIX}}git-snapshot{{end}}"
+  CONFIGURATION_PACKAGE: main
+  LDFLAGS: >-
+    -ldflags
+    '
+    -X {{.CONFIGURATION_PACKAGE}}.version={{.VERSION}}
+    '
+  # Path of the project's primary Go module:
+  DEFAULT_GO_MODULE_PATH: ./
+tasks:
+  # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/go-task/Taskfile.yml
+  go:build:
+    desc: Build the Go code
+    dir: "{{.DEFAULT_GO_MODULE_PATH}}"
+    cmds:
+      - go build -v {{.LDFLAGS}}


### PR DESCRIPTION
This will fix #21
I made [1.0.6-rc1](https://github.com/arduino/rp2040tools/releases/tag/1.0.6-rc1) to test things out and it works just fine:
```
./rp2040load -v
rp2040load 1.0.6-rc1 - compiled with go1.16.2
```