### PR TITLE
Add sync labels badge to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Check Markdown status](https://github.com/arduino/rp2040tools/actions/workflows/check-markdown-task.yml/badge.svg)](https://github.com/arduino/rp2040tools/actions/workflows/check-markdown-task.yml)
 [![Check Prettier Formatting status](https://github.com/arduino/rp2040tools/actions/workflows/check-prettier-formatting-task.yml/badge.svg)](https://github.com/arduino/rp2040tools/actions/workflows/check-prettier-formatting-task.yml)
 [![Check Taskfiles status](https://github.com/arduino/rp2040tools/actions/workflows/check-taskfiles.yml/badge.svg)](https://github.com/arduino/rp2040tools/actions/workflows/check-taskfiles.yml)
+[![Sync Labels status](https://github.com/arduino/rp2040tools/actions/workflows/sync-labels.yml/badge.svg)](https://github.com/arduino/rp2040tools/actions/workflows/sync-labels.yml)
 
 This repo contains all the tools used by Arduino to upload compiled code to the boards that use the rp2040 processor.
 


### PR DESCRIPTION
Added a badge to [README.md](https://github.com/arduino/rp2040tools/blob/master/README.md) to show that checks made by [Sync-labels](https://github.com/arduino/rp2040tools/blob/master/.github/workflows/sync-labels.yml) are passing. [Sync-labels](https://github.com/arduino/rp2040tools/blob/master/.github/workflows/sync-labels.yml) itself was added to the workflows of this repository in PR #7 .